### PR TITLE
Update how to start jekyll

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -12,7 +12,7 @@ Quick setup:
 
 Start server locally when working on a draft:
 
-@jekyll serve --drafts --watch@
+@bundle exec jekyll serve --drafts --watch@
 
 Open "http://localhost:4000":http://localhost:4000
 


### PR DESCRIPTION
Just updating the README of how to start jekyll locally.

See #92.